### PR TITLE
Reconfigure Service\Authorize::addRoles to recursively add parent roles if they don't already exist

### DIFF
--- a/src/BjyAuthorize/Service/Authorize.php
+++ b/src/BjyAuthorize/Service/Authorize.php
@@ -163,8 +163,16 @@ class Authorize
 
     protected function addRoles($roles)
     {
+        if (!is_array($roles)) {
+            $roles = array($roles);
+        }
+
         foreach ($roles as $i) {
-            if ($i->getParent() === null) {
+            if ($this->acl->hasRole($i)) {
+                continue;
+            }
+            if ($i->getParent() !== null) {
+                $this->addRoles($i->getParent());
                 $this->acl->addRole($i, $i->getParent());
             } else {
                 $this->acl->addRole($i);


### PR DESCRIPTION
Background:  When setting up my roles using the ZendDb provider, I inserted them in the "wrong" order: 

```
mysql> select * from user_role;
+-------------+---------+--------+
| role_id     | default | parent |
+-------------+---------+--------+
| guest       |       1 | NULL   |
| super_admin |       0 | user   |
| user        |       0 | guest  |
+-------------+---------+--------+
```

The attached 
Since roles are added in the order they are returned from the db query, this triggered exceptions:

```
Zend\Acl\Exception\InvalidArgumentException: Role 'user' not found
Zend\Acl\Exception\InvalidArgumentException: Parent Role id "user" does not exist
```

Attached code changes `BjyAuthorize\Service\Authorize::addRoles` to add any referenced parents before adding the child role to ACL. 
