### PR TITLE
Update ZendDb role provider to build role hierarchy so that recursive pa...

### DIFF
--- a/src/BjyAuthorize/Provider/Role/ZendDb.php
+++ b/src/BjyAuthorize/Provider/Role/ZendDb.php
@@ -43,10 +43,19 @@ class ZendDb implements ProviderInterface
         $rowset = $tableGateway->selectWith($sql);
 
         $roles = array();
+        // Pass One: Build each object
         foreach ($rowset as $row) {
-            $roles[] = new Role($row[$this->roleIdFieldName], $row[$this->parentRoleFieldName]);
+            $roleId = $row[$this->roleIdFieldName];
+            $roles[$roleId] = new Role($roleId, $row[$this->parentRoleFieldName]);
+        }
+        // Pass Two: Re-inject parent objects to preserve hierarchy
+        foreach ($roles as $roleId=>$roleObj) {
+            $parentRoleObj = $roleObj->getParent();
+            if ($parentRoleObj) {
+                $roleObj->setParent($roles[$parentRoleObj->getRoleId()]);
+            }
         }
 
-        return $roles;
+        return array_values($roles);
     }
 }


### PR DESCRIPTION
Currently, when using the ZendDb role provider only the first-level parent associations are retained (ie: guest <- user).  If you define a parent for 'user' (ie: guest <- user <- admin ) it will be lost:

```
object(BjyAuthorize\Acl\Role)[269]
  protected 'roleId' => string 'super_admin' (length=11)
  protected 'default' => null
    protected 'parent' => 
      object(BjyAuthorize\Acl\Role)[275]
        protected 'roleId' => string 'user' (length=4)
        protected 'default' => null
        protected 'parent' => null     ## <-- Should not be NULL
```

I've updated the ZendDb provider to retain the complete inheritance like the Config provider does. 
