### PR TITLE
Added method Service\Authorize::getAcl

### DIFF
--- a/src/BjyAuthorize/Service/Authorize.php
+++ b/src/BjyAuthorize/Service/Authorize.php
@@ -117,6 +117,11 @@ class Authorize
         return 'bjyauthorize-identity';
     }
 
+    public function getAcl()
+    {
+        return $this->acl;
+    }
+
     public function isAllowed($resource, $privilege = null)
     {
         if (!$this->loaded) {


### PR DESCRIPTION
Allows pulling out the internal Zend\Permissions\Acl\Acl object for outside use (ie: Zend\Navigation<->ACL integration)
