### PR TITLE
Removing unused methods from guard interface

### DIFF
--- a/src/BjyAuthorize/Guard/GuardInterface.php
+++ b/src/BjyAuthorize/Guard/GuardInterface.php
@@ -7,9 +7,4 @@ use Zend\EventManager\ListenerAggregateInterface;
 
 interface GuardInterface extends ListenerAggregateInterface
 {
-    public function getResources();
-
-    public function attach(EventManagerInterface $events);
-
-    public function detach(EventManagerInterface $events);
 }


### PR DESCRIPTION
Those methods were already defined in [`Zend\EventManager\ListenerAggregateInterface`](https://github.com/zendframework/zf2/blob/master/library/Zend/EventManager/ListenerAggregateInterface.php) and `getResources` is already provided by [`BjyAuthorize\Provider\Resource\ProviderInterface`](https://github.com/bjyoungblood/BjyAuthorize/blob/master/src/BjyAuthorize/Provider/Resource/ProviderInterface.php)

This is conflicting with PHP `<5.4`
