### PR TITLE
Compatable to ZF2.1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "zendframework/zendframework": "2.0.*",
+        "zendframework/zendframework": "2.*",
         "zf-commons/zfc-base": "dev-master",
         "zf-commons/zfc-user": "dev-master"
     },


### PR DESCRIPTION
Compatable to ZF2.1.x....

For development purpose... The old composer.json had 2.0.x in it... 
