### PR TITLE
getOrCreateService ignores options for ZendDb

### DIFF
--- a/config/services.config.php
+++ b/config/services.config.php
@@ -49,7 +49,11 @@ return array(
         },
 
         'BjyAuthorize\Provider\Role\ZendDb' => function (ServiceLocatorInterface $serviceLocator) {
-            return new Provider\Role\ZendDb(array(), $serviceLocator);
+            $config = $serviceLocator->get('Config');
+
+            foreach ($config['bjyauthorize']['role_providers'] as $class => $options) {
+                return new $class($options, $serviceLocator);
+            }
         },
 
         'BjyAuthorize\Provider\Role\Doctrine' => 'BjyAuthorize\Service\DoctrineRoleProviderFactory',


### PR DESCRIPTION
How mentioned in Issue #60 but to Doctrine. Fixing to ZendDb.
