### PR TITLE
Acl not initialized

### DIFF
--- a/src/BjyAuthorize/Service/Authorize.php
+++ b/src/BjyAuthorize/Service/Authorize.php
@@ -207,6 +207,10 @@ class Authorize
      */
     public function getAcl()
     {
+        if (!$this->loaded) {
+            $this->load();
+        }
+
         return $this->acl;
     }
 


### PR DESCRIPTION
Hi,

I was playing with Zend\Navigation and noticed that the Acl wasn't being initialized, here is a quick fix for that
