### PR TITLE
new Provider AuthenticationZfcDoctrineProvider 

### DIFF
--- a/config/services.config.php
+++ b/config/services.config.php
@@ -41,7 +41,16 @@ return array(
 
             return new Provider\Identity\ZfcUserDoctrine($objectManager, $userService);
         },
+        
+        'BjyAuthorize\Provider\Identity\AuthenticationZfcUserDoctrine' => function (ServiceLocatorInterface $serviceLocator) {
+            /* @var $objectManager \Doctrine\ORM\EntityManager */
+            $objectManager = $serviceLocator->get('doctrine.entitymanager.orm_default');
+            /* @var $userService \ZfcUser\Service\User */
+            $userService   = $serviceLocator->get('zfcuser_user_service');
 
+            return new Provider\Identity\AuthenticationZfcUserDoctrine($objectManager, $userService);
+        },
+      
         'BjyAuthorize\View\UnauthorizedStrategy' => function (ServiceLocatorInterface $serviceLocator) {
             $config = $serviceLocator->get('Config');
 

--- a/src/BjyAuthorize/Provider/Identity/AuthenticationZfcUserDoctrine.php
+++ b/src/BjyAuthorize/Provider/Identity/AuthenticationZfcUserDoctrine.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * BjyAuthorize Module (https://github.com/bjyoungblood/BjyAuthorize)
+ *
+ * @link https://github.com/bjyoungblood/BjyAuthorize for the canonical source repository
+ * @license http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace BjyAuthorize\Provider\Identity;
+
+use Doctrine\ORM\EntityManager;
+use ZfcUser\Service\User;
+use Zend\Permissions\Acl\Role\RoleInterface;
+use Zend\Authentication\AuthenticationService;
+
+/**
+ * Identity provider based on {@see \Doctrine\ORM\EntityManager}
+ *
+ * @author Ben Youngblood <bx.youngblood@gmail.com>
+ *
+ * @deprecated you should use {@see \BjyAuthorize\Provider\Identity\AuthenticationDoctrineEntity} instead
+ */
+class AuthenticationZfcUserDoctrine extends ZfcUserDoctrine implements ProviderInterface {
+
+    /**
+     * @var string|\Zend\Permissions\Acl\Role\RoleInterface
+     */
+    protected $defaultRole;
+
+    /**
+     * @var string|\Zend\Permissions\Acl\Role\RoleInterface
+     */
+    protected $authenticatedRoles = array();
+
+    /**
+     * Get the rule that's used if you're authenticated
+     *
+     * @return string
+     */
+    public function getAuthenticatedRoles() {
+        return $this->authenticatedRoles;
+    }
+
+    /**
+     * Set the role that's used if you're authenticated
+     *
+     * @param string $authenticatedRole
+     */
+    public function setAuthenticatedRole($authenticatedRole) {
+        $this->authenticatedRoles[] = $authenticatedRole;
+    }
+
+}


### PR DESCRIPTION
I ran into case That I need default role as `guest` and about  3 authenticated roles `user` , `senior` , `admin`  not as currently one authenticated role as string . 
I think in this case none of available provider will  help me , so I tried to create a new provider `AuthenticationZfcUserDoctrine`  provider that seems to work well 

could you please review it 
