### PR TITLE
Minor schema changes

### DIFF
--- a/data/schema.sql
+++ b/data/schema.sql
@@ -1,13 +1,14 @@
-CREATE TABLE IF NOT EXISTS `user_role` (
-  `role_id` varchar(255) NOT NULL,
-  `default` tinyint(1) NOT NULL,
-  `parent` varchar(255) DEFAULT NULL,
-  PRIMARY KEY (`role_id`)
+CREATE TABLE IF NOT EXISTS user_role (
+  role_id varchar(32) CHARACTER SET latin1 NOT NULL,
+  is_default tinyint(1) NOT NULL,
+  parent varchar(32) CHARACTER SET latin1  DEFAULT NULL,
+  PRIMARY KEY (role_id),
+  FOREIGN KEY parent_role (parent) REFERENCES user_role(role_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-CREATE TABLE IF NOT EXISTS `user_role_linker` (
-  `user_id` int(11) unsigned NOT NULL,
-  `role_id` varchar(255) NOT NULL,
-  PRIMARY KEY (`user_id`,`role_id`),
-  KEY `role_id` (`role_id`)
+CREATE TABLE IF NOT EXISTS user_role_linker (
+  user_id int(11) unsigned NOT NULL,
+  role_id varchar(32) CHARACTER SET latin1 NOT NULL,
+  PRIMARY KEY (user_id, role_id),
+  FOREIGN KEY role (role_id) REFERENCES user_role(role_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
- 'default' is a reserved keyword in mysql, so I changed it to
  is_default. I have not seen an occurrence of this column in the
  actual code, so impact seems minimal.
- Although a parent column is present, it did not have a foreign
  key yet, so added that.
- The character set was set to utf8, given that role names are
  something used internally, and the fact that they're used as
  primary keys, I figured they could better be latin1 (reasoning below)
- Because Mysql reserves the maximum amount of bytes for a varchar
  field, it would reserve 3*255 bytes (3 because of charset, 255
  because of maxlenght). This seems a tad overkill, hence I reduced
  it to a more sensible amount (I think).

Oh, I would propose to also change the table name to user_x_role (or role_x_user, alphabetically) instead of user_role_linker as that would be more in line with naming conventions, but I figured that would break BC, so left that out.
