### PR TITLE
Using new composer version for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,20 @@
 language: php
 
 php:
+  - 5.3.3
   - 5.3
   - 5.4
   - 5.5
 
+matrix:
+  allow_failures:
+    - php: 5.5
+
 before_script:
-  - composer update --prefer-source --dev
+  - curl -s https://getcomposer.org/installer | php && php composer.phar update --prefer-source --dev
   - wget http://cs.sensiolabs.org/get/php-cs-fixer.phar
 
 script:
   - phpunit
-  - php coverage-checker.php clover.xml 36
+  - php coverage-checker.php clover.xml 55
   - output=$(php php-cs-fixer.phar fix -v --dry-run --level=psr2 ./src/); if [[ $output ]]; then while read -r line; do echo -e "\e[00;31m$line\e[00m"; done <<< "$output"; false; fi;


### PR DESCRIPTION
This should fix the builds

Also adds 5.5 and 5.3.3 to the build matrix, since the package is quite small.
