### PR TITLE
Added BjyAuthorize\Service\ConfigRuleProviderServiceFactory

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -51,6 +51,7 @@ return array(
             'BjyAuthorize\Guard\Route'              => 'BjyAuthorize\Service\RouteGuardServiceFactory',
             'BjyAuthorize\Provider\Role\Config'     => 'BjyAuthorize\Service\ConfigRoleProviderServiceFactory',
             'BjyAuthorize\Provider\Role\ZendDb'     => 'BjyAuthorize\Service\ZendDbRoleProviderServiceFactory',
+			'BjyAuthorize\Provider\Rule\Config'     => 'BjyAuthorize\Service\ConfigRuleProviderServiceFactory',
             'BjyAuthorize\Provider\Resource\Config' => 'BjyAuthorize\Service\ConfigResourceProviderServiceFactory',
             'BjyAuthorize\Service\Authorize'        => 'BjyAuthorize\Service\AuthorizeFactory',
             'BjyAuthorize\Provider\Identity\ProviderInterface'

--- a/src/BjyAuthorize/Service/ConfigRuleProviderServiceFactory.php
+++ b/src/BjyAuthorize/Service/ConfigRuleProviderServiceFactory.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * BjyAuthorize Module (https://github.com/bjyoungblood/BjyAuthorize)
+ *
+ * @link https://github.com/bjyoungblood/BjyAuthorize for the canonical source repository
+ * @license http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace BjyAuthorize\Service;
+
+use BjyAuthorize\Provider\Rule\Config;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * Factory responsible of instantiating {@see \BjyAuthorize\Provider\Rule\Config}
+ *
+ * @author Marco Pivetta <ocramius@gmail.com>
+ */
+class ConfigRuleProviderServiceFactory implements FactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @return \BjyAuthorize\Provider\Rule\Config
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        $config = $serviceLocator->get('BjyAuthorize\Config');
+
+        return new Config($config['rule_providers']['BjyAuthorize\Provider\Rule\Config']);
+    }
+}


### PR DESCRIPTION
The rule_providers values from the module config weren't being loaded. (See @webdevilopers comments in issue #116). A `BjyAuthorize\Provider\Role\Config` was created at the appropriate time, but without the values defined in the module config being passed to the constructor. 

The factory class included in this pull request ensures that the config values are passed to the `BjyAuthorize\Provider\Role\Config` object as they should.
