### PR TITLE
Inject view model with 403 error as result instead of default error view model

### DIFF
--- a/src/BjyAuthorize/View/UnauthorizedStrategy.php
+++ b/src/BjyAuthorize/View/UnauthorizedStrategy.php
@@ -50,7 +50,7 @@ class UnauthorizedStrategy implements ListenerAggregateInterface
      */
     public function attach(EventManagerInterface $events)
     {
-        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH_ERROR, array($this, 'onDispatchError'), -5000);
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH_ERROR, array($this, 'onDispatchError'), -50);
     }
 
     /**
@@ -136,7 +136,7 @@ class UnauthorizedStrategy implements ListenerAggregateInterface
         $response = $response ?: new HttpResponse();
 
         $model->setTemplate($this->getTemplate());
-        $event->getViewModel()->addChild($model);
+        $event->setResult($model);
         $response->setStatusCode(403);
         $event->setResponse($response);
     }

--- a/tests/BjyAuthorizeTest/View/UnauthorizedStrategyTest.php
+++ b/tests/BjyAuthorizeTest/View/UnauthorizedStrategyTest.php
@@ -95,9 +95,9 @@ class UnauthorizedStrategyTest extends PHPUnit_Framework_TestCase
 
         $test = $this;
 
-        $viewModel
+        $mvcEvent
             ->expects($this->once())
-            ->method('addChild')
+            ->method('setResult')
             ->with(
                 $this->callback(
                     function (ModelInterface $model) use ($test) {


### PR DESCRIPTION
Replace the result with default error view model on our view model before calling `InjectViewModelListener::injectViewModel`
