### PR TITLE
Fix listener attachment in controller guard

### DIFF
--- a/src/BjyAuthorize/Guard/Controller.php
+++ b/src/BjyAuthorize/Guard/Controller.php
@@ -75,7 +75,7 @@ class Controller implements GuardInterface, RuleProviderInterface, ResourceProvi
      */
     public function attach(EventManagerInterface $events)
     {
-        $this->listeners[] = $events->attach(MvcEvent::EVENT_ROUTE, array($this, 'onDispatch'), -1000);
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, array($this, 'onDispatch'), -1000);
     }
 
     /**


### PR DESCRIPTION
Controller guard must attach listener on \Zend\Mvc\MvcEvent::EVENT_DISPATCH event as described in class docblock.
