### PR TITLE
Added the requested URI in a 'redirect' GET param to redirection URL

### DIFF
--- a/src/BjyAuthorize/View/RedirectionStrategy.php
+++ b/src/BjyAuthorize/View/RedirectionStrategy.php
@@ -93,6 +93,11 @@ class RedirectionStrategy implements ListenerAggregateInterface
             $url = $router->assemble(array(), array('name' => $this->redirectRoute));
         }
 
+        if ($event->getRequest() && ($uri = $event->getRequest()->getRequestUri())) {
+            $sep = (false === strpos($url, '?')) ? '?' : '&';
+            $url .= $sep . 'redirect=' . urlencode($uri);
+        }
+        
         $response = $response ?: new Response();
 
         $response->getHeaders()->addHeaderLine('Location', $url);


### PR DESCRIPTION
In order to redirect the successfully authenticated user to his originally requested URL (which is automatically supported by ZfcUser module through the 'use_redirect_parameter_if_present' config option), why not adding a 'redirect' GET param to the redirection URL ?
Regards.
