### PR TITLE
Fixed the user_role_linker query to refer to user_role table configurable table/column names

### DIFF
--- a/src/BjyAuthorize/Provider/Identity/ZfcUserZendDb.php
+++ b/src/BjyAuthorize/Provider/Identity/ZfcUserZendDb.php
@@ -32,11 +32,6 @@ class ZfcUserZendDb implements ProviderInterface
     protected $defaultRole;
 
     /**
-     * @var string
-     */
-    protected $tableName = 'user_role_linker';
-
-    /**
      * @var \Zend\Db\TableGateway\TableGateway
      */
     private $tableGateway;
@@ -65,9 +60,14 @@ class ZfcUserZendDb implements ProviderInterface
         // get roles associated with the logged in user
         $sql = new Select();
 
-        $sql->from($this->tableName);
-        // @todo these fields should eventually be configurable
-        $sql->join('user_role', 'user_role.id = ' . $this->tableName . '.role_id');
+        $sql->from($this->tableGateway->getTable());
+
+        $config = $this->userService->getServiceManager()->get( 'Config' );
+        $roleTable = $config['bjyauthorize']['role_providers']['BjyAuthorize\Provider\Role\ZendDb']['table'];
+        $idField = $config['bjyauthorize']['role_providers']['BjyAuthorize\Provider\Role\ZendDb']['identifier_field_name'];
+        $roleIdField = $config['bjyauthorize']['role_providers']['BjyAuthorize\Provider\Role\ZendDb']['role_id_field'];
+
+        $sql->join($roleTable, $roleTable. '.'. $idField .' = ' . $this->tableGateway->getTable() . '.' . $roleIdField);
         $sql->where(array('user_id' => $authService->getIdentity()->getId()));
 
         $results = $this->tableGateway->selectWith($sql);

--- a/src/BjyAuthorize/Provider/Identity/ZfcUserZendDb.php
+++ b/src/BjyAuthorize/Provider/Identity/ZfcUserZendDb.php
@@ -57,7 +57,9 @@ class ZfcUserZendDb implements ProviderInterface
             return array($this->getDefaultRole());
         }
 
-        list($tableName, $identifierFieldName) = $this->getRoleProviderTableMeta($this->userService->getServiceManager()->get('BjyAuthorize\Config'));
+        $config = $this->userService->getServiceManager()->get('BjyAuthorize\Config');
+        $tableName = $this->getUserRoleTableName($config);
+        $identifierFieldName = $this->getUserRoleIdentifierFieldName($config);
 
         // get roles associated with the logged in user
         $sql = new Select();
@@ -74,15 +76,6 @@ class ZfcUserZendDb implements ProviderInterface
         }
 
         return $roles;
-    }
-
-    /**
-     * @param $config
-     * @return array
-     */
-    public function getRoleProviderTableMeta($config)
-    {
-        return array($this->getUserRoleTableName($config), $this->getUserRoleIdentifierFieldName($config));
     }
 
     /**

--- a/src/BjyAuthorize/Provider/Identity/ZfcUserZendDb.php
+++ b/src/BjyAuthorize/Provider/Identity/ZfcUserZendDb.php
@@ -57,17 +57,15 @@ class ZfcUserZendDb implements ProviderInterface
             return array($this->getDefaultRole());
         }
 
+        $roleProvider = $this->getZendDbRoleProvider();
+
         // get roles associated with the logged in user
         $sql = new Select();
-
         $sql->from($this->tableGateway->getTable());
-
-        $config = $this->userService->getServiceManager()->get( 'Config' );
-        $roleTable = $config['bjyauthorize']['role_providers']['BjyAuthorize\Provider\Role\ZendDb']['table'];
-        $idField = $config['bjyauthorize']['role_providers']['BjyAuthorize\Provider\Role\ZendDb']['identifier_field_name'];
-        $roleIdField = $config['bjyauthorize']['role_providers']['BjyAuthorize\Provider\Role\ZendDb']['role_id_field'];
-
-        $sql->join($roleTable, $roleTable. '.'. $idField .' = ' . $this->tableGateway->getTable() . '.' . $roleIdField);
+        $sql->join($roleProvider->getTableName(), $roleProvider->getTableName() . '.' .
+            $roleProvider->getIdentifierFieldName() . ' = ' . $this->tableGateway->getTable() . '.' .
+            $roleProvider->getRoleIdFieldName()
+        );
         $sql->where(array('user_id' => $authService->getIdentity()->getId()));
 
         $results = $this->tableGateway->selectWith($sql);
@@ -79,6 +77,14 @@ class ZfcUserZendDb implements ProviderInterface
         }
 
         return $roles;
+    }
+
+    /**
+     * @return \BjyAuthorize\Provider\Role\ZendDb
+     */
+    private function getZendDbRoleProvider()
+    {
+        return $this->userService->getServiceManager()->get('BjyAuthorize\Provider\Role\ZendDb');
     }
 
     /**

--- a/src/BjyAuthorize/Provider/Identity/ZfcUserZendDb.php
+++ b/src/BjyAuthorize/Provider/Identity/ZfcUserZendDb.php
@@ -68,8 +68,11 @@ class ZfcUserZendDb implements ProviderInterface
         // get roles associated with the logged in user
         $sql = new Select();
         $sql->from($this->tableGateway->getTable());
-        $sql->join($this->zendDbRole->getTableName(), $this->zendDbRole->getTableName() . '.' .
-            $this->zendDbRole->getIdentifierFieldName() . ' = ' . $this->tableGateway->getTable() . '.role_id');
+        $sql->join(
+            $this->zendDbRole->getTableName(),
+            $this->zendDbRole->getTableName() . '.' . $this->zendDbRole->getIdentifierFieldName() . ' = ' .
+            $this->tableGateway->getTable() . '.role_id'
+        );
         $sql->where(array('user_id' => $authService->getIdentity()->getId()));
 
         $results = $this->tableGateway->selectWith($sql);

--- a/src/BjyAuthorize/Provider/Role/ZendDb.php
+++ b/src/BjyAuthorize/Provider/Role/ZendDb.php
@@ -70,38 +70,6 @@ class ZendDb implements ProviderInterface
     }
 
     /**
-     * @return string
-     */
-    public function getIdentifierFieldName()
-    {
-        return $this->identifierFieldName;
-    }
-
-    /**
-     * @return string
-     */
-    public function getParentRoleFieldName()
-    {
-        return $this->parentRoleFieldName;
-    }
-
-    /**
-     * @return string
-     */
-    public function getRoleIdFieldName()
-    {
-        return $this->roleIdFieldName;
-    }
-
-    /**
-     * @return string
-     */
-    public function getTableName()
-    {
-        return $this->tableName;
-    }
-
-    /**
      * {@inheritDoc}
      */
     public function getRoles()

--- a/src/BjyAuthorize/Provider/Role/ZendDb.php
+++ b/src/BjyAuthorize/Provider/Role/ZendDb.php
@@ -45,6 +45,22 @@ class ZendDb implements ProviderInterface
     protected $parentRoleFieldName = 'parent_id';
 
     /**
+     * @return string
+     */
+    public function getTableName()
+    {
+        return $this->tableName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIdentifierFieldName()
+    {
+        return $this->identifierFieldName;
+    }
+
+    /**
      * @param                         $options
      * @param ServiceLocatorInterface $serviceLocator
      */

--- a/src/BjyAuthorize/Provider/Role/ZendDb.php
+++ b/src/BjyAuthorize/Provider/Role/ZendDb.php
@@ -70,6 +70,38 @@ class ZendDb implements ProviderInterface
     }
 
     /**
+     * @return string
+     */
+    public function getIdentifierFieldName()
+    {
+        return $this->identifierFieldName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getParentRoleFieldName()
+    {
+        return $this->parentRoleFieldName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRoleIdFieldName()
+    {
+        return $this->roleIdFieldName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTableName()
+    {
+        return $this->tableName;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getRoles()

--- a/src/BjyAuthorize/Service/ZfcUserZendDbIdentityProviderServiceFactory.php
+++ b/src/BjyAuthorize/Service/ZfcUserZendDbIdentityProviderServiceFactory.php
@@ -32,8 +32,9 @@ class ZfcUserZendDbIdentityProviderServiceFactory implements FactoryInterface
         /* @var $userService \ZfcUser\Service\User */
         $userService = $serviceLocator->get('zfcuser_user_service');
         $config      = $serviceLocator->get('BjyAuthorize\Config');
+        $zendDbRole  = $serviceLocator->get('BjyAuthorize\Provider\Role\ZendDb');
 
-        $provider = new ZfcUserZendDb($tableGateway, $userService);
+        $provider = new ZfcUserZendDb($tableGateway, $userService, $zendDbRole);
 
         $provider->setDefaultRole($config['default_role']);
 

--- a/tests/BjyAuthorizeTest/Provider/Identity/ZfcUserZendDbTest.php
+++ b/tests/BjyAuthorizeTest/Provider/Identity/ZfcUserZendDbTest.php
@@ -10,7 +10,6 @@ namespace BjyAuthorizeTest\Provider\Identity;
 
 use PHPUnit_Framework_TestCase;
 use BjyAuthorize\Provider\Identity\ZfcUserZendDb;
-use BjyAuthorize\Service\ZendDbRoleProviderServiceFactory;
 
 /**
  * {@see \BjyAuthorize\Provider\Identity\ZfcUserZendDb} test
@@ -59,14 +58,6 @@ class ZfcUserZendDbTest extends PHPUnit_Framework_TestCase
         $this->provider = new ZfcUserZendDb($this->tableGateway, $this->userService);
     }
 
-    public function testGetZendDbRoleProvider()
-    {
-        $factory        = new ZendDbRoleProviderServiceFactory();
-        $serviceLocator = $this->getMock('Zend\\ServiceManager\\ServiceLocatorInterface');
-        $roleProvider   = $factory->createService($serviceLocator);
-        $this->assertInstanceOf('BjyAuthorize\\Provider\\Role\\ZendDb', $roleProvider);
-    }
-
     /**
      * @covers \BjyAuthorize\Provider\Identity\ZfcUserZendDb::getIdentityRoles
      * @covers \BjyAuthorize\Provider\Identity\ZfcUserZendDb::setDefaultRole
@@ -101,5 +92,12 @@ class ZfcUserZendDbTest extends PHPUnit_Framework_TestCase
     {
         $roles = $this->provider->getIdentityRoles();
         $this->assertEquals($roles, array(null));
+    }
+
+    public function testEmptyRoleProviderConfig()
+    {
+        list($tableName, $identifierFieldName) = $this->provider->getRoleProviderTableMeta(array());
+        $this->assertSame('user_role', $tableName);
+        $this->assertSame('id', $identifierFieldName);
     }
 }

--- a/tests/BjyAuthorizeTest/Provider/Identity/ZfcUserZendDbTest.php
+++ b/tests/BjyAuthorizeTest/Provider/Identity/ZfcUserZendDbTest.php
@@ -10,6 +10,7 @@ namespace BjyAuthorizeTest\Provider\Identity;
 
 use PHPUnit_Framework_TestCase;
 use BjyAuthorize\Provider\Identity\ZfcUserZendDb;
+use BjyAuthorize\Provider\Role\ZendDb;
 
 /**
  * {@see \BjyAuthorize\Provider\Identity\ZfcUserZendDb} test
@@ -52,7 +53,7 @@ class ZfcUserZendDbTest extends PHPUnit_Framework_TestCase
     {
         $this->authService  = $this->getMock('Zend\Authentication\AuthenticationService');
         $this->userService  = $this->getMock('ZfcUser\Service\User');
-        $this->zendDbRole   = $this->getMock('BjyAuthorize\Provider\Role\ZendDb');
+        $this->zendDbRole   = new ZendDb(array(), $this->getMock('Zend\ServiceManager\ServiceLocatorInterface'));
         $this->tableGateway = $this->getMock('Zend\Db\TableGateway\TableGateway', array(), array(), '', false);
 
         $this

--- a/tests/BjyAuthorizeTest/Provider/Identity/ZfcUserZendDbTest.php
+++ b/tests/BjyAuthorizeTest/Provider/Identity/ZfcUserZendDbTest.php
@@ -39,6 +39,11 @@ class ZfcUserZendDbTest extends PHPUnit_Framework_TestCase
     protected $provider;
 
     /**
+     * @var \BjyAuthorize\Provider\Role\ZendDb
+     */
+    protected $zendDbRole;
+
+    /**
      * {@inheritDoc}
      *
      * @covers \BjyAuthorize\Provider\Identity\ZfcUserZendDb::__construct
@@ -47,6 +52,7 @@ class ZfcUserZendDbTest extends PHPUnit_Framework_TestCase
     {
         $this->authService  = $this->getMock('Zend\Authentication\AuthenticationService');
         $this->userService  = $this->getMock('ZfcUser\Service\User');
+        $this->zendDbRole   = $this->getMock('BjyAuthorize\Provider\Role\ZendDb');
         $this->tableGateway = $this->getMock('Zend\Db\TableGateway\TableGateway', array(), array(), '', false);
 
         $this
@@ -55,7 +61,7 @@ class ZfcUserZendDbTest extends PHPUnit_Framework_TestCase
             ->method('getAuthService')
             ->will($this->returnValue($this->authService));
 
-        $this->provider = new ZfcUserZendDb($this->tableGateway, $this->userService);
+        $this->provider = new ZfcUserZendDb($this->tableGateway, $this->userService, $this->zendDbRole);
     }
 
     /**
@@ -92,12 +98,5 @@ class ZfcUserZendDbTest extends PHPUnit_Framework_TestCase
     {
         $roles = $this->provider->getIdentityRoles();
         $this->assertEquals($roles, array(null));
-    }
-
-    public function testEmptyRoleProviderConfig()
-    {
-        list($tableName, $identifierFieldName) = $this->provider->getRoleProviderTableMeta(array());
-        $this->assertSame('user_role', $tableName);
-        $this->assertSame('id', $identifierFieldName);
     }
 }

--- a/tests/BjyAuthorizeTest/Provider/Identity/ZfcUserZendDbTest.php
+++ b/tests/BjyAuthorizeTest/Provider/Identity/ZfcUserZendDbTest.php
@@ -10,6 +10,7 @@ namespace BjyAuthorizeTest\Provider\Identity;
 
 use PHPUnit_Framework_TestCase;
 use BjyAuthorize\Provider\Identity\ZfcUserZendDb;
+use BjyAuthorize\Service\ZendDbRoleProviderServiceFactory;
 
 /**
  * {@see \BjyAuthorize\Provider\Identity\ZfcUserZendDb} test
@@ -56,6 +57,14 @@ class ZfcUserZendDbTest extends PHPUnit_Framework_TestCase
             ->will($this->returnValue($this->authService));
 
         $this->provider = new ZfcUserZendDb($this->tableGateway, $this->userService);
+    }
+
+    public function testGetZendDbRoleProvider()
+    {
+        $factory        = new ZendDbRoleProviderServiceFactory();
+        $serviceLocator = $this->getMock('Zend\\ServiceManager\\ServiceLocatorInterface');
+        $roleProvider   = $factory->createService($serviceLocator);
+        $this->assertInstanceOf('BjyAuthorize\\Provider\\Role\\ZendDb', $roleProvider);
     }
 
     /**


### PR DESCRIPTION
Fixed the user_role_linker query to refer to user_role table configurable table/column names
Removed unnecessary reference to user_role_linker table as tableGateway already has reference to it
