### PR TITLE
Notice fix

### DIFF
--- a/src/BjyAuthorize/Provider/Role/ZendDb.php
+++ b/src/BjyAuthorize/Provider/Role/ZendDb.php
@@ -92,7 +92,7 @@ class ZendDb implements ProviderInterface
 
         // Pass 2: build a role for each indexed row
         foreach ($indexedRows as $row) {
-            $parentRoleId   = isset($row[$this->parentRoleFieldName])
+            $parentRoleId   = !empty($row[$this->parentRoleFieldName])
                 ? $indexedRows[$row[$this->parentRoleFieldName]][$this->roleIdFieldName] : null;
             $roleId         = $row[$this->roleIdFieldName];
             $roles[$roleId] = new Role($roleId, $parentRoleId);


### PR DESCRIPTION
This fixes a notice in case a parent role field name is set, but no
parent is defined for a certain role.
