### PR TITLE
Enhancement: Strtolower action names in Guard\Controller::getResourceName()

### DIFF
--- a/src/BjyAuthorize/Guard/Controller.php
+++ b/src/BjyAuthorize/Guard/Controller.php
@@ -60,7 +60,7 @@ class Controller extends AbstractGuard
     public function getResourceName($controller, $action = null)
     {
         if (isset($action)) {
-            return sprintf('controller/%s:%s', $controller, $action);
+            return sprintf('controller/%s:%s', $controller, strtolower($action));
         }
 
         return sprintf('controller/%s', $controller);

--- a/tests/BjyAuthorizeTest/Guard/ControllerTest.php
+++ b/tests/BjyAuthorizeTest/Guard/ControllerTest.php
@@ -132,6 +132,7 @@ class ControllerTest extends PHPUnit_Framework_TestCase
     {
         $this->assertSame('controller/test1:action1', $this->controllerGuard->getResourceName('test1', 'action1'));
         $this->assertSame('controller/test2', $this->controllerGuard->getResourceName('test2'));
+        $this->assertSame('controller/test3:get', $this->controllerGuard->getResourceName('test3', 'GET'));
     }
 
     /**


### PR DESCRIPTION
:bulb: This is for people who like to use constants

Because the mehod name is `strtolower`ed - see this: 

``` php
<?php

namespace BjyAuthorize\Guard;

class Controller
{

    public function onDispatch(MvcEvent $event)
    {
        // . . . .
        $method     = $request instanceof HttpRequest ? strtolower($request->getMethod()) : null;

        $authorized = $service->isAllowed($this->getResourceName($controller))
            || $service->isAllowed($this->getResourceName($controller, $action))
            || ($method && $service->isAllowed($this->getResourceName($controller, $method)));
        // . . . 
}
```

I suggest to `strtolower` `$action` in `getResourceName()`.

This allows for specifying configuration like this:

``` php
<?php

use BjyAuthorize\Guard;
use Foo\Controller;
use Foo\Entity;
use Zend\Http;

return [
    'bjyauthorize' => [
        'guards' => [
            Guard\Controller::class => [
                //allow all anonymous OPTIONS requests
                [
                    'controller' => Controller\BarController::class,
                    'action' => Http\Request::METHOD_POST,
                    'roles' => [
                        Entity\User::ROLE_GUEST,
                        Entity\User::ROLE_USER,
                    ]
                ],
            ],
        ],
    ],
];
```
