### PR TITLE
Added check for ACL resource before calling isAllowed()

### DIFF
--- a/src/BjyAuthorize/Service/Authorize.php
+++ b/src/BjyAuthorize/Service/Authorize.php
@@ -239,6 +239,10 @@ class Authorize
         $this->loaded && $this->loaded->__invoke();
 
         try {
+            // Check if the acl has the resource before checking for isAllowed
+            if (!$this->acl->hasResource($resource)) {
+                return false;
+            }
             return $this->acl->isAllowed($this->getIdentity(), $resource, $privilege);
         } catch (InvalidArgumentException $e) {
             return false;


### PR DESCRIPTION
Adding this check if the resource is available in the ACL will prevent PHP errors if resource was not added or isn't available.
