### PR TITLE
AuthIdentityProvider accepts AuthServiceInterface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,13 +26,13 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.3",
-        "zendframework/zend-permissions-acl": "~2.2",
-        "zendframework/zend-mvc":             "~2.2",
-        "zendframework/zend-eventmanager":    "~2.2",
-        "zendframework/zend-servicemanager":  "~2.2",
-        "zendframework/zend-http":            "~2.2",
-        "zendframework/zend-view":            "~2.2",
-        "zendframework/zend-cache":           "~2.2"
+        "zendframework/zend-permissions-acl": "~2.3",
+        "zendframework/zend-mvc":             "~2.3",
+        "zendframework/zend-eventmanager":    "~2.3",
+        "zendframework/zend-servicemanager":  "~2.3",
+        "zendframework/zend-http":            "~2.3",
+        "zendframework/zend-view":            "~2.3",
+        "zendframework/zend-cache":           "~2.3"
     },
     "require-dev": {
         "phpunit/phpunit":                    "~3.7",

--- a/src/BjyAuthorize/Provider/Identity/AuthenticationIdentityProvider.php
+++ b/src/BjyAuthorize/Provider/Identity/AuthenticationIdentityProvider.php
@@ -11,7 +11,7 @@ namespace BjyAuthorize\Provider\Identity;
 use BjyAuthorize\Exception\InvalidRoleException;
 use BjyAuthorize\Provider\Role\ProviderInterface as RoleProviderInterface;
 use Zend\Permissions\Acl\Role\RoleInterface;
-use Zend\Authentication\AuthenticationService;
+use Zend\Authentication\AuthenticationServiceInterface;
 
 /**
  * Simple identity provider to handle simply guest|user
@@ -21,7 +21,7 @@ use Zend\Authentication\AuthenticationService;
 class AuthenticationIdentityProvider implements ProviderInterface
 {
     /**
-     * @var AuthenticationService
+     * @var AuthenticationServiceInterface
      */
     protected $authService;
 
@@ -36,9 +36,9 @@ class AuthenticationIdentityProvider implements ProviderInterface
     protected $authenticatedRole = 'user';
 
     /**
-     * @param AuthenticationService $authService
+     * @param AuthenticationServiceInterface $authService
      */
-    public function __construct(AuthenticationService $authService)
+    public function __construct(AuthenticationServiceInterface $authService)
     {
         $this->authService = $authService;
     }


### PR DESCRIPTION
The constructor of `BjyAuthorize\Provider\Identity\AuthenticationIdentityProvider` can accept the `AuthenticationServiceInterface` rather than a `AuthenticationService` to make it less restrictive. I have this need in a project I'm working on at the moment. Thinking others might as well.