### PR TITLE
add support for aggregated assertions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.3",
-        "zendframework/zend-permissions-acl": "~2.2",
+        "zendframework/zend-permissions-acl": "~2.3",
         "zendframework/zend-mvc":             "~2.2",
         "zendframework/zend-eventmanager":    "~2.2",
         "zendframework/zend-servicemanager":  "~2.2",


### PR DESCRIPTION
**WIP**

I would very much like to see multiple assertions per rule supported. 

`[['guest', 'user'], 'pants', 'wear', ['IsOwner', 'IsJeans']]`

What needs to be done:
- [x] Bump minimum requirement of `zend-permissions-acl` to 2.3 in order to use `AssertionAggregate`
- [ ] Support `AssertionAggregate::MODE` configuration
- [ ] Add tests

Before I continue I would like your opinion about this. Personally, I need this.
