### PR TITLE
Adds $this to the setter as return value in User Entity and Role Entity

### DIFF
--- a/data/Role.php.dist
+++ b/data/Role.php.dist
@@ -57,11 +57,12 @@ class Role implements HierarchicalRoleInterface
      *
      * @param int $id
      *
-     * @return void
+     * @return Role
      */
     public function setId($id)
     {
         $this->id = (int)$id;
+        return $this;
     }
 
     /**
@@ -79,11 +80,12 @@ class Role implements HierarchicalRoleInterface
      *
      * @param string $roleId
      *
-     * @return void
+     * @return Role
      */
     public function setRoleId($roleId)
     {
         $this->roleId = (string) $roleId;
+        return $this;
     }
 
     /**
@@ -101,10 +103,11 @@ class Role implements HierarchicalRoleInterface
      *
      * @param Role $parent
      *
-     * @return void
+     * @return Role
      */
     public function setParent(Role $parent)
     {
         $this->parent = $parent;
+        return $this;
     }
 }

--- a/data/User.php.dist
+++ b/data/User.php.dist
@@ -94,11 +94,12 @@ class User implements UserInterface, ProviderInterface
      *
      * @param int $id
      *
-     * @return void
+     * @return User
      */
     public function setId($id)
     {
         $this->id = (int) $id;
+        return $this;
     }
 
     /**
@@ -116,11 +117,12 @@ class User implements UserInterface, ProviderInterface
      *
      * @param string $username
      *
-     * @return void
+     * @return User
      */
     public function setUsername($username)
     {
         $this->username = $username;
+        return $this;
     }
 
     /**
@@ -138,11 +140,12 @@ class User implements UserInterface, ProviderInterface
      *
      * @param string $email
      *
-     * @return void
+     * @return User
      */
     public function setEmail($email)
     {
         $this->email = $email;
+        return $this;
     }
 
     /**
@@ -160,11 +163,12 @@ class User implements UserInterface, ProviderInterface
      *
      * @param string $displayName
      *
-     * @return void
+     * @return User
      */
     public function setDisplayName($displayName)
     {
         $this->displayName = $displayName;
+        return $this;
     }
 
     /**
@@ -182,11 +186,12 @@ class User implements UserInterface, ProviderInterface
      *
      * @param string $password
      *
-     * @return void
+     * @return User
      */
     public function setPassword($password)
     {
         $this->password = $password;
+        return $this;
     }
 
     /**
@@ -204,11 +209,12 @@ class User implements UserInterface, ProviderInterface
      *
      * @param int $state
      *
-     * @return void
+     * @return User
      */
     public function setState($state)
     {
         $this->state = $state;
+        return $this;
     }
 
     /**
@@ -226,10 +232,11 @@ class User implements UserInterface, ProviderInterface
      *
      * @param Role $role
      *
-     * @return void
+     * @return User
      */
     public function addRole($role)
     {
         $this->roles[] = $role;
+        return $this;
     }
 }


### PR DESCRIPTION
Adds $this to the setter as return value in User Entity and Role Entity, so that it work in other modules with the use of a continuous method call syntax.
For example, in the Authentication\Adapter\HybridAuth.php module of the socalnick\scn-social-auth, is the use of $user->setEmail ($email) ->setDisplayName ($displayName)...... And the like.

在User Entity和 Role Entity 的 setter 中添加 $this 作为返回，以便在使用连续调用语法的其他模块中正常使用。
例如在 socalnick\scn-social-auth 模块的 Authentication\Adapter\HybridAuth.php 中，就是使用了 $user->setEmail($email)->setDisplayName($displayName) ……之类的语法。