### PR TITLE
Create cache adapter using serviceLocator in CacheFactory

### DIFF
--- a/src/BjyAuthorize/Service/CacheFactory.php
+++ b/src/BjyAuthorize/Service/CacheFactory.php
@@ -28,8 +28,21 @@ class CacheFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
+        $adapterName = null;
         $options = $serviceLocator->get('BjyAuthorize\Config');
+        if (is_array($options)
+            && isset($options['cache_options'])
+            && isset($options['cache_options']['adapter'])
+            && isset($options['cache_options']['adapter']['name'])
+        ) {
+            $adapterName = $options['cache_options']['adapter']['name'];
+        }
 
-        return StorageFactory::factory($options['cache_options']);
+        // Create adapter via serviceLocator if possible
+        if (!empty($adapterName) && $serviceLocator->has($adapterName)) {
+            return $serviceLocator->get($adapterName);
+        } else {
+            return StorageFactory::factory($options['cache_options']);
+        }
     }
 }

--- a/tests/BjyAuthorizeTest/Service/CacheFactoryTest.php
+++ b/tests/BjyAuthorizeTest/Service/CacheFactoryTest.php
@@ -10,6 +10,7 @@ namespace BjyAuthorizeTest\Service;
 
 use BjyAuthorize\Service\CacheFactory;
 use PHPUnit_Framework_TestCase;
+use Zend\Cache\Storage\Adapter\Memory;
 
 /**
  * PHPUnit tests for {@see \BjyAuthorize\Service\CacheFactory}
@@ -23,13 +24,13 @@ class CacheFactoryTest extends PHPUnit_Framework_TestCase
      */
     public function testCreateService()
     {
-        $serviceLocator = $this->getMock('Zend\\ServiceManager\\ServiceLocatorInterface');
-        $config         = array(
+        $serviceLocator = $this->getMock('Zend\\ServiceManager\\ServiceLocatorInterface', array('get', 'has'));
+        $config = array(
             'cache_options' => array(
-                'adapter'   => array(
+                'adapter' => array(
                     'name' => 'memory',
                 ),
-                'plugins'   => array(
+                'plugins' => array(
                     'serializer',
                 )
             )
@@ -40,6 +41,52 @@ class CacheFactoryTest extends PHPUnit_Framework_TestCase
             ->method('get')
             ->with('BjyAuthorize\Config')
             ->will($this->returnValue($config));
+
+        $serviceLocator
+            ->expects($this->any())
+            ->method('has')
+            ->with('memory')
+            ->will($this->returnValue(false));
+
+        $factory = new CacheFactory();
+
+        $this->assertInstanceOf('Zend\Cache\Storage\Adapter\Memory', $factory->createService($serviceLocator));
+    }
+
+    /**
+     * @covers \BjyAuthorize\Service\CacheFactory::createService
+     */
+    public function testCreateServiceViaServiceLocator()
+    {
+        $serviceLocator = $this->getMock('Zend\\ServiceManager\\ServiceLocatorInterface', array('get', 'has'));
+        $config = array(
+            'cache_options' => array(
+                'adapter' => array(
+                    'name' => 'memory',
+                ),
+                'plugins' => array(
+                    'serializer',
+                )
+            )
+        );
+
+        $serviceLocator
+            ->expects($this->at(0))
+            ->method('get')
+            ->with('BjyAuthorize\Config')
+            ->will($this->returnValue($config));
+
+        $serviceLocator
+            ->expects($this->at(1))
+            ->method('has')
+            ->with('memory')
+            ->will($this->returnValue(true));
+
+        $serviceLocator
+            ->expects($this->at(2))
+            ->method('get')
+            ->with('memory')
+            ->will($this->returnValue(new Memory()));
 
         $factory = new CacheFactory();
 


### PR DESCRIPTION
Updated `BjyAuthorize\Service\CacheFactory` to create cache adapter via service locator if possible otherwise via static StorageFactory. For instance if you want to use a specific memcached server/cluster and/or you want to prefix the namespace.

e.g. That way it's possible to use the `Zend\Cache\Storage\Adapter\MemcachedResourceManager` and custom factories to created individual `Zend\Cache\Storage\Adapter\Memcached` instances with a custom `Zend\Cache\Storage\Adapter\MemcachedOptions` implementation.
